### PR TITLE
Syntax error

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -237,4 +237,4 @@ ReactDOM.render(
 ```
 [](codepen://conditional-rendering/4)
 
-Ritornando `null` dal metodo `render` di un componente, non modifica il comportamnento dei metodi di lifecycle del componente. Ad esempio `componentDidUpdate` viene ancora chiamato.
+Ritornando `null` dal metodo `render` di un componente, non modifica il comportamento dei metodi di lifecycle del componente. Ad esempio `componentDidUpdate` viene ancora chiamato.


### PR DESCRIPTION
"comportamnento" to "comportamento"



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
