### PR TITLE
Fix missing translations in state-and-lifecycle.md

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -325,14 +325,14 @@ Ci sono tre cose che devi sapere a proposito di `setState()`.
 Per esempio, questo codice non farebbe ri-renderizzare un componente:
 
 ```js
-// Wrong
+// Sbagliato
 this.state.comment = 'Hello';
 ```
 
 Devi invece utilizzare `setState()`:
 
 ```js
-// Correct
+// Giusto
 this.setState({comment: 'Hello'});
 ```
 


### PR DESCRIPTION
There's a couple of comments in code examples which are not translated in Italian, while other comments are.
I just fixed those translations using same comments used as translations in other code examples.