### PR TITLE
Fix for a small syntax error of a link

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -10,7 +10,7 @@ redirect_from:
 
 In React, puoi creare componenti distinti che incapsulano il funzionamento di cui hai bisogno. Quindi, puoi renderizzarne solo alcuni, a seconda dello stato della tua applicazione.
 
-La renderizzazione condizionale in React funziona nello stesso modo in cui funzionano le condizioni in JavaScript. Puoi perciò usare operatori come [`if`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else) o l'[operatore condizionale]([https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Conditional_Operator](https://developer.mozilla.org/it/docs/Web/JavaScript/Reference/Operators/Operator_Condizionale)) per creare elementi che rappresentano lo stato corrente cosicché React possa aggiornare la UI di conseguenza.
+La renderizzazione condizionale in React funziona nello stesso modo in cui funzionano le condizioni in JavaScript. Puoi perciò usare operatori come [`if`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/if...else) o l'[operatore condizionale](https://developer.mozilla.org/it/docs/Web/JavaScript/Reference/Operators/Operator_Condizionale) per creare elementi che rappresentano lo stato corrente cosicché React possa aggiornare la UI di conseguenza.
 
 Considera i due componenti:
 


### PR DESCRIPTION
While reading the documentation i noticed this small syntax error on an external link.

Greetings 😃