### PR TITLE
Translate Reconciliation 

### DIFF
--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -167,4 +167,4 @@ Dato che React si basa su euristiche, se le assunzioni iniziali non vengono risp
 
 1. L'algoritmo non cercherà di confrontare sottoalberi di tipi di componente diverso. Se il tuo caso è quello di alternare tra due componenti con diverso tipo ma con output molto simile, potresti renderli dello stesso tipo. in pratica, non abbiamo trovato problemi nel farlo.
 
-2. Le chiavi dovrebbero essere stabili, predicibili ed univoche. Chiavi non stabili (come quell prodotte da `Math.random()`) causeranno la ricreazione unutile di diverse istanze dei componenti e nodi DOM, ciò può causare degradazione delle prestazioni e perdita di state nei componenti figlio.
+2. Le chiavi dovrebbero essere stabili, predicibili ed univoche. Chiavi non stabili (come quell prodotte da `Math.random()`) causeranno l'inutile ricreazione di diverse istanze dei componenti e nodi DOM, ciò può causare degradazione delle prestazioni e perdita di state nei componenti figlio.


### PR DESCRIPTION
Ciao, I finished the issue #71 .
On the _"Chiavi"_ paragraph, I chose to keep using `key` instead of translating it as 'chiave' because, in my opinion, it is more clear for the user that _we are specifically referring to the prop itself_, not only the concept. Let me know if it is ok for you to keep using 'key'. If that is the case, maybe we could consider to add it in the [Glossary](https://github.com/reactjs/it.reactjs.org/blob/master/GLOSSARY.md). Let me know if I should fix something on the translation or on the sentences and I will do it asap 😄 👍 